### PR TITLE
Removing wp_kses escaping function from JavaScript output.

### DIFF
--- a/includes/class-genesis-simple-share-front-end.php
+++ b/includes/class-genesis-simple-share-front-end.php
@@ -234,7 +234,8 @@ class Genesis_Simple_Share_Front_End {
 
 		if ( 'before_content' === $position || 'both' === $position ) {
 
-			echo wp_kses_post( $this->get_icon_output( 'before', $this->icons ) );
+			// phpcs:ignore
+			echo $this->get_icon_output( 'before', $this->icons );
 
 		}
 
@@ -260,7 +261,8 @@ class Genesis_Simple_Share_Front_End {
 
 		if ( 'after_content' === $position || 'both' === $position ) {
 
-			echo wp_kses_post( $this->get_icon_output( 'after', $this->icons ) );
+			// phpcs:ignore
+			echo $this->get_icon_output( 'after', $this->icons );
 
 		}
 
@@ -814,6 +816,7 @@ function genesis_share_get_icon_output( $position, $icons = array(), $force_show
  */
 function genesis_share_icon_output( $position, $icons = array(), $force_show = false, $url = '' ) {
 
-	echo wp_kses_post( genesis_share_get_icon_output( $position, $icons, $force_show, $url ) );
+	// phpcs:ignore
+	echo genesis_share_get_icon_output( $position, $icons, $force_show, $url ) );
 
 }

--- a/includes/class-genesis-simple-share-front-end.php
+++ b/includes/class-genesis-simple-share-front-end.php
@@ -817,6 +817,6 @@ function genesis_share_get_icon_output( $position, $icons = array(), $force_show
 function genesis_share_icon_output( $position, $icons = array(), $force_show = false, $url = '' ) {
 
 	// phpcs:ignore
-	echo genesis_share_get_icon_output( $position, $icons, $force_show, $url ) );
+	echo genesis_share_get_icon_output( $position, $icons, $force_show, $url );
 
 }

--- a/plugin.php
+++ b/plugin.php
@@ -1,10 +1,9 @@
 <?php
 /**
- *
  * Plugin Name: Genesis Simple Share
  * Plugin URI: https://wordpress.org/plugins/genesis-simple-share/
  * Description: A simple sharing plugin using the Share script.
- * Version: 1.1.2
+ * Version: 1.1.3
  * Author: StudioPress
  * Author URI: https://www.studiopress.com
  *

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: nathanrice, studiopress, wpmuguru, nick_thegeek, bgardner, marksabbath
 Tags: genesis, share, share buttons, facebook, twitter, pinterest, stumbleupon, linkedin, social
 Requires at least: 3.7
-Tested up to: 5.1
-Stable tag: 1.1.2
+Tested up to: 5.1.1
+Stable tag: 1.1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ https://github.com/copyblogger/genesis-simple-share/wiki/Usage-Tips
 
 
 == Changelog ==
+
+= 1.1.3 =
+* Fixed a bug where the share buttons where not showing.
 
 = 1.1.2 =
 * Dropped Google+ support.


### PR DESCRIPTION
This PR would resolve the recent issue experienced by some users where the JavaScript is being shown in the frontend as a text, not as script.