### PR TITLE
Hotfix/object returning null

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
 	},
 	"require-dev": {
 		"php": "^5.6 || ^7",
-        "dealerdirect/phpcodesniffer-composer-installer": "*",
-        "squizlabs/php_codesniffer": "^3.3.1",
-        "phpcompatibility/phpcompatibility-wp": "*",
+		"dealerdirect/phpcodesniffer-composer-installer": "*",
+		"squizlabs/php_codesniffer": "^3.3.1",
+		"phpcompatibility/phpcompatibility-wp": "*",
 		"wp-coding-standards/wpcs": "^1"
 	},
 	"config": {
@@ -22,8 +22,8 @@
 	"prefer-stable": true,
 	"scripts": {
 		"phpcs": "phpcs --standard=WordPress --ignore=vendor/,node_modules/,assets/ --extensions=php -p ./",
-        "phpcs-compat": "phpcs --extensions=php --standard=PHPCompatibilityWP --ignore=vendor/,node_modules/,assets/ --runtime-set testVersion 5.6- -p ./",
-        "phpcbf": "phpcbf --standard=WordPress --ignore=vendor/,node_modules/,assets/ --extensions=php -p ./"
+		"phpcs-compat": "phpcs --extensions=php --standard=PHPCompatibilityWP --ignore=vendor/,node_modules/,assets/ --runtime-set testVersion 5.6- -p ./",
+		"phpcbf": "phpcbf --standard=WordPress --ignore=vendor/,node_modules/,assets/ --extensions=php -p ./"
 	},
 	"support": {
 		"issues": "https://github.com/studiopress/genesis-simple-share/issues",

--- a/includes/class-genesis-simple-share-front-end.php
+++ b/includes/class-genesis-simple-share-front-end.php
@@ -768,15 +768,18 @@ class Genesis_Simple_Share_Front_End {
  * @since 0.1.0
  */
 function genesis_simple_share() {
-	global $genesis_simple_share;
+	// Backward compatibility.
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName.NotSnakeCase
+	global $Genesis_Simple_Share;
 
-	if ( empty( $genesis_simple_share ) ) {
+	if ( empty( $Genesis_Simple_Share ) ) {
 
-		$genesis_simple_share = new Genesis_Simple_Share_Front_End();
+		$Genesis_Simple_Share = new Genesis_Simple_Share_Front_End();
 
 	}
 
-	return $genesis_simple_share;
+	return $Genesis_Simple_Share;
+	// phpcs:enable
 
 }
 

--- a/includes/class-genesis-simple-share-preview.php
+++ b/includes/class-genesis-simple-share-preview.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 0.1.0
  */
-class Gensis_Simple_Share_Preview {
+class Genesis_Simple_Share_Preview {
 
 	/**
 	 * Icons.
@@ -152,6 +152,9 @@ class Gensis_Simple_Share_Preview {
 
 			$div_id = strtolower( $icon . '-' . $location . '-' . $id );
 
+			// Disable the counter if the option is set or is the Facebook.
+			$disable_count = genesis_get_option( 'general_disable_count', 'genesis_simple_share' ) || ( 'facebook' === $icon ) ? 'disableCount: true,' : '';
+
 			// media.
 			$button = '';
 
@@ -163,6 +166,7 @@ class Gensis_Simple_Share_Preview {
 									  urlCurl: '%s',
 									  enableHover: false,
 									  enableTracking: true,
+										%s
 									  buttons: { %s },
 									  click: function(api, options){
 									    api.simulateClick();
@@ -172,6 +176,7 @@ class Gensis_Simple_Share_Preview {
 				$div_id,
 				$icon,
 				GENESIS_SIMPLE_SHARE_URL . '/assets/js/sharrre/sharrre.php',
+				$disable_count,
 				$button,
 				$icon
 			);
@@ -297,7 +302,7 @@ class Gensis_Simple_Share_Preview {
 function genesis_simple_share_preview() {
 	global $genesis_simple_share;
 
-	$genesis_simple_share = new Gensis_Simple_Share_Preview();
+	$genesis_simple_share = new Genesis_Simple_Share_Preview();
 
 }
 
@@ -311,9 +316,12 @@ genesis_simple_share_preview();
  * @param array  $icons    array of icons to use when building output.
  */
 function genesis_share_get_icon_preview_output( $position, $icons = array() ) {
-	global $genesis_simple_share;
+	// Backward compatibility.
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName.NotSnakeCase
+	global $Genesis_Simple_Share;
 
-	return $genesis_simple_share->get_icon_output( $position, $icons );
+	return $Genesis_Simple_Share->get_icon_output( $position, $icons );
+	// phpcs:enable
 
 }
 

--- a/includes/class-genesis-simple-share-preview.php
+++ b/includes/class-genesis-simple-share-preview.php
@@ -300,9 +300,13 @@ class Genesis_Simple_Share_Preview {
  * Global object.
  */
 function genesis_simple_share_preview() {
-	global $genesis_simple_share;
+	// Backward compatibility.
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName.NotSnakeCase
+	global $Genesis_Simple_Share;
 
-	$genesis_simple_share = new Genesis_Simple_Share_Preview();
+	$Genesis_Simple_Share = new Genesis_Simple_Share_Preview();
+
+	// phpcs:enable
 
 }
 

--- a/includes/class-genesis-simple-share-preview.php
+++ b/includes/class-genesis-simple-share-preview.php
@@ -160,19 +160,19 @@ class Genesis_Simple_Share_Preview {
 
 			$scripts .= sprintf(
 				"$('#%s').sharrre({
-									  share: {
-									    %s: true
-									  },
-									  urlCurl: '%s',
-									  enableHover: false,
-									  enableTracking: true,
-										%s
-									  buttons: { %s },
-									  click: function(api, options){
-									    api.simulateClick();
-									    api.openPopup('%s');
-									  }
-									});\n",
+					share: {
+						%s: true
+					},
+					urlCurl: '%s',
+					enableHover: false,
+					enableTracking: true,
+					%s,
+					buttons: { %s },
+					click: function(api, options){
+						api.simulateClick();
+						api.openPopup('%s');
+					}
+				});\n",
 				$div_id,
 				$icon,
 				GENESIS_SIMPLE_SHARE_URL . '/assets/js/sharrre/sharrre.php',


### PR DESCRIPTION
These updates should resolve the error reported here: https://wordpress.org/support/topic/object-returning-null-wpengine-hosting/

To test this:
- Install this plugin, enable and configure it (Under the Genesis->Simple Share menu);
- Add the following code into any page in the WordPress site:
```
if( function_exists( 'genesis_share_get_icon_output' ) ) {
     global $Genesis_Simple_Share;
     echo '<div class="share-icons">';
          echo '<div class="share-icons__icon"></div>';
          genesis_share_icon_output( 'icons__con', $Genesis_Simple_Share->icons );
     echo '</div>';
```
It should show the icons where you added the code.