### PR TITLE
Version Bump to Reflect WordPress 5.2.2 Testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "description": "A simple sharing plugin using the Share script.",
     "author": "StudioPress",
     "authoruri": "http://www.studiopress.com/",
-    "version": "1.1.1",
+    "version": "1.1.5",
     "license": "GPL-2.0+",
     "licenseuri": "http://www.gnu.org/licenses/gpl-2.0.html",
     "textdomain": "genesis-simple-share"

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Genesis Simple Share
  * Plugin URI: https://wordpress.org/plugins/genesis-simple-share/
  * Description: A simple sharing plugin using the Share script.
- * Version: 1.1.4
+ * Version: 1.1.5
  * Author: StudioPress
  * Author URI: https://www.studiopress.com
  *
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( esc_html__( 'Sorry, you are not allowed to access this page directly.', 'genesis-simple-share' ) );
 }
 
-define( 'GENESIS_SIMPLE_SHARE_VERSION', '1.1.4' );
+define( 'GENESIS_SIMPLE_SHARE_VERSION', '1.1.5' );
 define( 'GENESIS_SIMPLE_SHARE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'GENESIS_SIMPLE_SHARE_INC', plugin_dir_path( __FILE__ ) . '/includes/' );
 define( 'GENESIS_SIMPLE_SHARE_URL', plugins_url( '', __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: nathanrice, studiopress, wpmuguru, nick_thegeek, bgardner, marksabbath
 Tags: genesis, share, share buttons, facebook, twitter, pinterest, stumbleupon, linkedin, social
 Requires at least: 3.7
-Tested up to: 5.1.1
-Stable tag: 1.1.4
+Tested up to: 5.2.2
+Stable tag: 1.1.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ https://github.com/copyblogger/genesis-simple-share/wiki/Usage-Tips
 
 
 == Changelog ==
+
+= 1.1.5 =
+* Tested on WordPress 5.2.2
 
 = 1.1.4 =
 * Removed Facebook counter.


### PR DESCRIPTION
**Summary of change:**
Version Bump to Reflect Testing with WordPress 5.2.2

**This PR has been:**
- [x] Linted for syntax errors
- [x] Tested against the WordPress coding standards
- [x] Tested with the bundled test suite(s)
